### PR TITLE
add dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.3.0
+
+ENV WORKER_PROCESSES 4
+ENV DATABASE_URL postgres://postgres:mysecretpassword@postgres/fixer
+ENV VERSION 1
+
+RUN mkdir /fixer-io
+WORKDIR /fixer-io
+ADD Gemfile /fixer-io/Gemfile
+ADD Gemfile.lock /fixer-io/Gemfile.lock
+RUN bundle install --deployment --without development:test
+ADD . /fixer-io
+
+EXPOSE 8080
+
+CMD bundle exec unicorn -p 8080 -c /fixer-io/config/unicorn.rb

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Fixer.io
+
 [![Travis](https://travis-ci.org/hakanensari/fixer-io.svg)](https://travis-ci.org/hakanensari/fixer-io)
 
 <img src="http://fixer.io/img/money.png" alt="fixer" width=180 align="middle">
@@ -5,3 +7,14 @@
 Fixer.io is a free JSON API for current and historical foreign exchange rates published by the European Central Bank.
 
 The rates are updated daily around 3PM CET.
+
+
+## Docker
+
+
+```
+# bring the stack up
+docker-compose up -d
+# initialize the database (postgres need a short time to come up)
+docker-compose run fixer rake db:migrate rates:load
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  postgres:
+    image: postgres
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_DB=fixer
+  fixer:
+    build: .
+    command: bundle exec unicorn -p 8080 -c /fixer-io/config/unicorn.rb
+    volumes:
+      - .:/fixer-io
+    ports:
+      - 8080:8080
+    environment:
+      - RACK_ENV=production
+      - DATABASE_URL=postgres://postgres:mysecretpassword@postgres/fixer
+    depends_on:
+      - postgres


### PR DESCRIPTION
I want to run fixer-io in our company to prevent a single point of failure, so I create a Dockerfile and a small docker-compose.yml to run it locally. 

What do you think about this approach to run in the Docker Environment? It would be also very nice to extend the readme. It was not so easy - as a non-ruby developer - to start and configure the application.
