### PR TITLE
Currency Converter

### DIFF
--- a/lib/converter.rb
+++ b/lib/converter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'bigdecimal'
+require 'quote'
+
+class Converter
+  attr_reader :to, :from
+
+  def initialize(params = {})
+    @amount = params[:amount]
+    @from   = params[:from]
+    @to     = params[:to]
+  end
+
+  # Converts an amount into a new currency
+  # @param quote [Quote] the quote object
+  # @return amount [BigDecimal] the converted amount
+  def convert(quote = latest_quote)
+    return amount if quote.base == to
+    amount * quote.rates.fetch(to) { raise Quote::Invalid, 'Invalid to' }
+  end
+
+  def amount
+    BigDecimal(@amount.to_s)
+  end
+
+  private
+
+  def latest_quote
+    @latest_quote ||= Quote.new(base: from)
+  end
+end

--- a/lib/quote.rb
+++ b/lib/quote.rb
@@ -35,7 +35,7 @@ class Quote
     raise Invalid, 'Date too old' unless current_date
     @date = current_date
   rescue Sequel::DatabaseError => ex
-    if ex.wrapped_exception.is_a?(PG::DatetimeFieldOverflow)
+    if ex.wrapped_exception.is_a?(PG::DataException)
       raise Invalid, 'Invalid date'
     else
       raise

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -66,4 +66,9 @@ describe 'the API' do
       assert headers.key?('Access-Control-Allow-Methods')
     end
   end
+
+  it 'returns converted amount' do
+    get '/converter?to=USD&amount=100'
+    json['amount'].wont_be :nil?
+  end
 end

--- a/spec/converter_spec.rb
+++ b/spec/converter_spec.rb
@@ -1,0 +1,45 @@
+require_relative 'helper'
+require 'converter'
+
+describe Converter do
+  let(:to) { 'USD' }
+  let(:from) { 'EUR' }
+  let(:amount) { '100.0' }
+
+  let(:converter) { Converter.new to: to, from: from, amount: amount }
+  let(:quote) { Quote.new }
+
+  describe '#amount' do
+    it 'casts to BigDecimal' do
+      converter.amount.must_be_kind_of BigDecimal
+    end
+  end
+
+  describe '#convert' do
+    it 'should return the amount' do
+      quote.stub :base, to do
+        converter.convert(quote).must_equal BigDecimal(amount)
+      end
+    end
+
+    it 'should use the rates to convert' do
+      quote.stub :rates, Hash(to => 1.2) do
+        converter.convert(quote).must_equal BigDecimal('120.0')
+      end
+    end
+
+    it 'should raise with invalid currency' do
+      quote.stub :rates, Hash.new do
+        -> { converter.convert(quote) }.must_raise Quote::Invalid, 'Invalid to'
+      end
+    end
+
+    it 'should use latest quote as default' do
+      quote.stub :rates, Hash(to => 1.3) do
+        converter.stub :latest_quote, quote do
+          converter.convert.must_equal 130.0
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a proposal to expose a new feature to the API for currency conversion. It used the proposal from #25, which is quite similar to what is done with the google currency tool, but with the time travel feature as a bonus!

As an example, a simple conversion from USD, to EUR:

```
/converter?from=USD&to=EUR&amount=100
```

I'm not sure about the current API response:

```
{ amount: AMOUNT }
```

That could be a bit more exhaustive with the `date`, or the query parameters referenced into the response (maybe into an query object).

If it would be merged into the project, the documentation is still missing, and the errors (and messages) could be better (mainly the one without parameters).
