### PR TITLE
Sort rates by the currency ISO code

### DIFF
--- a/app/spec/quote_spec.rb
+++ b/app/spec/quote_spec.rb
@@ -56,6 +56,12 @@ describe Quote do
         rate.must_equal 1.4296
       end
     end
+
+    it 'returns the currencies sorted' do
+      stub_rates 'BAZ' => 1.5, 'FOO' => 2, 'BAR' => 3, 'QUX' => 4 do |quote|
+        quote.rates.keys.must_equal quote.rates.keys.sort
+      end
+    end
   end
 
   describe 'when given an invalid base' do


### PR DESCRIPTION
I noticed on a website using the public Fixer API that the sorting order in the `/latest?base=USD` endpoint was kinda odd – EUR was listed at the end.

While developing this fix, I saw that the sort order is also dependent on how the database stores the values themselves.  Therefore I added a `order(:iso_code)` to the query.  However, this still does not solve the problem that EUR is at the end of the hash for a different base.  I fixed that by rewriting how the rates are rebased; instead of iterating over the hash and modifying it while doing so (:scream:), it now uses `Enumerable#map` to do that, sorts the outcome, and then makes a hash out of it.