### PR TITLE
Update docker-compose to handle newer versions of postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres
     volumes:
       - data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
   web:
     command: unicorn -c config/unicorn.rb
     entrypoint: bin/wait-for-it.sh db:5432 -s --


### PR DESCRIPTION
    Add fix for recent versions of Postgres that require a password be set or to explicitly trust the host

    For dev and for simplicity we set the POSTGRES_HOST_AUTH_METHOD=trust env var to not have to provide a password